### PR TITLE
docs(SBS-CHG-004): source-driven process

### DIFF
--- a/benchmark/change-management.md
+++ b/benchmark/change-management.md
@@ -87,21 +87,26 @@ Monitoring for unauthorized direct-in-production changes preserves deployment pr
 **Default Value:**  
 Salesforce does not provide built-in monitoring or alerting for unauthorized direct-in-production metadata changes; organizations must implement their own processes.
 
-### SBS-CHG-004: Establish Continuous Integration (CI)
+### SBS-CHG-004: Establish Source-Driven Development Process
 
-**Control Statement:** Meaningful changes to production orgs must be deployed by a source-driven, auditable, automated, and repeatable process.
+**Control Statement:** Meaningful changes must be deployed with a source-driven, automated deployment process.
 
 **Description:**  
-Organizations must introduce a source-driven development and deployment process that allows reliable deployments to production. The process must be repeatable.
+Organizations must track all meaningful changes to metadata in a centralized version control system. The process to deploy those changes must include appropriate validation and testing, and must be automated in a fashion that it is repeatable and deterministic. This control makes no assumptions on the complexity of the org and the need for modularization and general scalability of the deployment process. To be compliant, it is sufficient to keep track of changes in version control and deploy deterministically.
 
 **Rationale:**  
-Without adequate version control, it is almost impossible to recover in case of failure. 
+Without adequate version control and automation, it is almost impossible to recover in case of failure. It is one root cause for "configuration drift" (the situation, where sandboxes deviate from production orgs). Version control and automated delivery are fundamental to identify **who** made changes in case of problems.
 
 **Audit Procedure:**  
-
+1. Follow the procedure described in SBS-CHG-001 to enforce a designated deployment identity.
+2. Investigate all processes that propagated changes from development environments to production. 
+3. Flag all processes that did not use a centralized version control.
 
 **Remediation:**  
-
+1. Set up a version control system such as `git`.
+2. Ensure that the version control is centralized and accessible by all developers.
+3. Evaluate if a progressive transistion is necessary (gradually migrate metadata to source-driven process).
+4. Introduce appropriate measures that from now on, all changes are tracked in source.
 
 **Default Value:**  
 Salesforce allows changes of most metadata types on production by default.

--- a/benchmark/change-management.md
+++ b/benchmark/change-management.md
@@ -87,3 +87,21 @@ Monitoring for unauthorized direct-in-production changes preserves deployment pr
 **Default Value:**  
 Salesforce does not provide built-in monitoring or alerting for unauthorized direct-in-production metadata changes; organizations must implement their own processes.
 
+### SBS-CHG-004: Establish Continuous Integration (CI)
+
+**Control Statement:** Meaningful changes to production orgs must be deployed by a source-driven, auditable, automated, and repeatable process.
+
+**Description:**  
+Organizations must introduce a source-driven development and deployment process that allows reliable deployments to production. The process must be repeatable.
+
+**Rationale:**  
+Without adequate version control, it is almost impossible to recover in case of failure. 
+
+**Audit Procedure:**  
+
+
+**Remediation:**  
+
+
+**Default Value:**  
+Salesforce allows changes of most metadata types on production by default.


### PR DESCRIPTION
Here's my proposal (first draft) for a control in **Change Management** that ensures a source driven process. While writing it, I was not 100% sure if it really is related to **security**. But imho, it is absolutely fundamental for **safety**, and therefore more than a simple "best practice". That's why I decided to add it.

I tried to keep the balance and be not too opinionated about how an organisation should develop (e.g. what tooling). The important part I want to focus on is: keep track of changes, automate deployments, ensure determinism & repeatability.

That's why I tried to avoid "continuous integration" or too much vender naming. What do you think?