### PR TITLE
Add SBS-PERM-005/006/007: Non-Human Identity Governance Controls

### DIFF
--- a/benchmark/permissions.md
+++ b/benchmark/permissions.md
@@ -123,3 +123,42 @@ Super Admin–equivalent permissions grant unrestricted read and write access ac
 
 **Default Value:**  
 Salesforce does not limit the number of users who may receive **View All Data**, **Modify All Data**, or **Manage Users**, and does not maintain any system of record regarding administrative access.
+
+### SBS-PERM-005: Restrict Broad Privileges for Non-Human Identities
+
+**Control Statement:** Non-human identities (integration users, automation users, bot users, and API-only accounts) must not be assigned permissions that bypass sharing rules or grant administrative capabilities without documented business justification and implemented compensating controls.
+
+**Description:**  
+Non-human identities, including integration users, automation users, Einstein Bot users, and API-only accounts, must follow the principle of least privilege. These identities must not be granted broad privileges such as View All Data, Modify All Data, View All Users, Modify All Users, Manage Users, Author Apex, or other permissions that bypass object-level or record-level security unless explicitly required and documented. All non-human identities with broad privileges must be recorded in a system of record with business justification, owner identification, and documented compensating controls. Both justification and compensating controls are required for compliance.
+
+**Rationale:**  
+Non-human identities operate without human oversight and typically use persistent credentials (stored passwords, OAuth tokens, or certificates) that remain valid across sessions. Granting broad privileges to these identities creates significant security risk: compromised credentials provide attackers with extensive access to data and configuration, automated processes can cause widespread damage if misconfigured or exploited, and the lack of interactive human review means malicious activity may persist undetected. Unlike human users who may temporarily require elevated access for specific tasks, non-human identities with broad privileges represent a persistent attack surface. Restricting broad privileges to only necessary cases and requiring compensating controls reduces the blast radius of credential compromise and limits the potential for automated abuse.
+
+**Audit Procedure:**  
+1. Identify all non-human identities in the org by querying users where UserType indicates integration, automation, or bot usage, or where the user is designated as an API-only or service account.  
+2. For each non-human identity, enumerate all assigned permissions via profiles, permission sets, and permission set groups.  
+3. Flag any non-human identity with broad privileges including but not limited to: View All Data, Modify All Data, View All Users, Modify All Users, Manage Users, Author Apex, Customize Application, Modify Metadata, or any permission that bypasses sharing rules or grants administrative capabilities.  
+4. For each flagged identity, verify that the organization's system of record contains:  
+   - Documented business justification explaining why broad privileges are required,  
+   - Identification of the system owner or responsible party, and  
+   - Documented compensating controls (e.g., IP restrictions, OAuth scope limitations, monitoring/alerting, credential rotation policy, dedicated integration user per system).  
+5. Verify that documented compensating controls are actually implemented and active.  
+6. Flag as noncompliant any non-human identity with broad privileges that lacks documented justification, lacks documented compensating controls, or has compensating controls that are not implemented.
+
+**Remediation:**  
+1. Remove broad privileges from non-human identities that lack documented justification or do not require data bypass or administrative capabilities.  
+2. Replace broad privileges with object-specific permissions, custom permissions, and sharing rules that grant only the minimum access necessary for the identity's function.  
+3. For non-human identities that legitimately require broad privileges, document in the system of record:  
+   - Clear business justification (e.g., "ETL process requires read access to all Account and Contact records"),  
+   - System owner and responsible party,  
+   - Implemented compensating controls.  
+4. Implement compensating controls for all non-human identities with broad privileges, such as:  
+   - IP address restrictions limiting access to known integration endpoints,  
+   - OAuth scope limitations (if using OAuth),  
+   - Monitoring and alerting for authentication and data access activity,  
+   - Credential rotation policy with defined intervals,  
+   - Dedicated identity per integration (avoid shared service accounts).  
+5. Establish a periodic (e.g., quarterly) review process for all non-human identities with broad privileges to ensure justifications remain valid and compensating controls remain effective.
+
+**Default Value:**  
+Salesforce does not restrict the assignment of broad privileges to non-human identities. Administrators can assign any permission to any user type unless explicitly prevented by license limitations. No system of record or compensating control requirements exist by default.

--- a/benchmark/permissions.md
+++ b/benchmark/permissions.md
@@ -124,41 +124,105 @@ Super Admin–equivalent permissions grant unrestricted read and write access ac
 **Default Value:**  
 Salesforce does not limit the number of users who may receive **View All Data**, **Modify All Data**, or **Manage Users**, and does not maintain any system of record regarding administrative access.
 
-### SBS-PERM-005: Restrict Broad Privileges for Non-Human Identities
+### SBS-PERM-005: Maintain Inventory of Non-Human Identities
 
-**Control Statement:** Non-human identities (integration users, automation users, bot users, and API-only accounts) must not be assigned permissions that bypass sharing rules or grant administrative capabilities without documented business justification and implemented compensating controls.
+**Control Statement:** Organizations must maintain an authoritative inventory of all non-human identities, including integration users, automation users, bot users, and API-only accounts.
 
 **Description:**  
-Non-human identities, including integration users, automation users, Einstein Bot users, and API-only accounts, must follow the principle of least privilege. These identities must not be granted broad privileges such as View All Data, Modify All Data, View All Users, Modify All Users, Manage Users, Author Apex, or other permissions that bypass object-level or record-level security unless explicitly required and documented. All non-human identities with broad privileges must be recorded in a system of record with business justification, owner identification, and documented compensating controls. Both justification and compensating controls are required for compliance.
+Non-human identities operate without direct human oversight and often possess persistent credentials with elevated access. Organizations must maintain a complete and current inventory of all such identities to enable effective governance, access reviews, and incident response. The inventory must include identity type, purpose, owner, creation date, and last activity date.
 
 **Rationale:**  
-Non-human identities operate without human oversight and typically use persistent credentials (stored passwords, OAuth tokens, or certificates) that remain valid across sessions. Granting broad privileges to these identities creates significant security risk: compromised credentials provide attackers with extensive access to data and configuration, automated processes can cause widespread damage if misconfigured or exploited, and the lack of interactive human review means malicious activity may persist undetected. Unlike human users who may temporarily require elevated access for specific tasks, non-human identities with broad privileges represent a persistent attack surface. Restricting broad privileges to only necessary cases and requiring compensating controls reduces the blast radius of credential compromise and limits the potential for automated abuse.
+Without a comprehensive inventory, organizations cannot effectively govern non-human identity access, identify unused or orphaned accounts, or respond to security incidents involving automated access. Non-human identities are frequently created for integrations or automation projects and then forgotten, creating persistent security risks. An authoritative inventory is the foundation for all other non-human identity governance controls.
 
 **Audit Procedure:**  
-1. Identify all non-human identities in the org by querying users where UserType indicates integration, automation, or bot usage, or where the user is designated as an API-only or service account.  
-2. For each non-human identity, enumerate all assigned permissions via profiles, permission sets, and permission set groups.  
-3. Flag any non-human identity with broad privileges including but not limited to: View All Data, Modify All Data, View All Users, Modify All Users, Manage Users, Author Apex, Customize Application, Modify Metadata, or any permission that bypasses sharing rules or grants administrative capabilities.  
-4. For each flagged identity, verify that the organization's system of record contains:  
-   - Documented business justification explaining why broad privileges are required,  
-   - Identification of the system owner or responsible party, and  
-   - Documented compensating controls (e.g., IP restrictions, OAuth scope limitations, monitoring/alerting, credential rotation policy, dedicated integration user per system).  
-5. Verify that documented compensating controls are actually implemented and active.  
-6. Flag as noncompliant any non-human identity with broad privileges that lacks documented justification, lacks documented compensating controls, or has compensating controls that are not implemented.
+1. Request the organization's inventory of non-human identities
+2. Query Salesforce for all users where `IsActive = true` and any of the following conditions apply:
+   - Username contains "integration", "api", "bot", "automation", or "service"
+   - Profile name contains "Integration", "API", or similar indicators
+   - User has "API Only User" permission enabled
+   - User is associated with Einstein Bot or Flow automation
+3. Compare the inventory to the query results to identify discrepancies
+4. Verify the inventory includes: identity name, type, purpose, business owner, creation date, and last login date
+5. Confirm the inventory is reviewed and updated at least quarterly
 
 **Remediation:**  
-1. Remove broad privileges from non-human identities that lack documented justification or do not require data bypass or administrative capabilities.  
-2. Replace broad privileges with object-specific permissions, custom permissions, and sharing rules that grant only the minimum access necessary for the identity's function.  
-3. For non-human identities that legitimately require broad privileges, document in the system of record:  
-   - Clear business justification (e.g., "ETL process requires read access to all Account and Contact records"),  
-   - System owner and responsible party,  
-   - Implemented compensating controls.  
-4. Implement compensating controls for all non-human identities with broad privileges, such as:  
-   - IP address restrictions limiting access to known integration endpoints,  
-   - OAuth scope limitations (if using OAuth),  
-   - Monitoring and alerting for authentication and data access activity,  
-   - Credential rotation policy with defined intervals,  
-   - Dedicated identity per integration (avoid shared service accounts).  
-5. Establish a periodic (e.g., quarterly) review process for all non-human identities with broad privileges to ensure justifications remain valid and compensating controls remain effective.
+1. Query Salesforce to identify all potential non-human identities using the criteria in the audit procedure
+2. For each identified identity, document: name, type (integration/bot/API), purpose, business owner, creation date
+3. Establish a process to update the inventory when non-human identities are created, modified, or deactivated
+4. Implement quarterly reviews of the inventory to identify and deactivate unused accounts
+5. Store the inventory in an authoritative system of record accessible to security and compliance teams
 
 **Default Value:**  
-Salesforce does not restrict the assignment of broad privileges to non-human identities. Administrators can assign any permission to any user type unless explicitly prevented by license limitations. No system of record or compensating control requirements exist by default.
+Salesforce does not provide a built-in inventory or classification system for non-human identities. Organizations must create and maintain this inventory manually or through third-party tools.
+
+### SBS-PERM-006: Restrict Broad Privileges for Non-Human Identities
+
+**Control Statement:** Non-human identities must not be granted elevated permissions through assignment of permissions that bypass sharing rules or grant administrative capabilities unless documented business justification exists.
+
+**Description:**  
+Non-human identities should follow the principle of least privilege and be granted only the minimum permissions necessary to perform their intended function. Permissions that bypass object-level or record-level security (such as View All Data, Modify All Data) or grant administrative capabilities (such as Manage Users, Modify Metadata) create significant security risk when assigned to automated accounts. Organizations must document a specific business justification for any non-human identity that requires such permissions.
+
+**Rationale:**  
+Non-human identities operate without human judgment or oversight, making over-privileged automation a high-impact security risk. Compromised credentials for a non-human identity with broad privileges can result in unauthorized data access, data exfiltration, or system-wide configuration changes. Many non-human identities are granted excessive permissions during initial setup and never reviewed, creating persistent security exposure. Requiring documented justification ensures that broad privileges are granted only when genuinely necessary and subject to approval.
+
+**Audit Procedure:**  
+1. Using the non-human identity inventory from SBS-PERM-005, identify all non-human identities
+2. For each non-human identity, query assigned permissions through profiles, permission sets, and permission set groups
+3. Flag any non-human identity with one or more of the following permissions:
+   - View All Data
+   - Modify All Data
+   - View All Users
+   - Modify All Users
+   - Manage Users
+   - Author Apex
+   - Customize Application
+   - Modify Metadata
+   - Any permission that bypasses sharing rules or grants administrative access
+4. For each flagged identity, verify that documented business justification exists explaining why the permission is required
+5. Confirm the justification was approved by appropriate stakeholders (security, compliance, or management)
+
+**Remediation:**  
+1. For each non-human identity with broad privileges, evaluate whether the permission is genuinely required for the identity's function
+2. Remove broad privileges that are not necessary; replace with more granular permissions where possible
+3. For non-human identities that legitimately require broad privileges, document:
+   - Specific business function requiring the permission
+   - Why more granular permissions cannot satisfy the requirement
+   - Business owner and technical owner
+   - Approval from security or compliance team
+4. Implement a formal approval process for granting broad privileges to non-human identities
+5. Establish periodic review (at least annually) of all non-human identities with broad privileges
+
+**Default Value:**  
+Salesforce does not restrict the assignment of broad privileges to non-human identities. Administrators can grant any permission to any user type without requiring justification or approval.
+
+### SBS-PERM-007: Implement Compensating Controls for Privileged Non-Human Identities
+
+**Control Statement:** Non-human identities with elevated permissions that bypass sharing rules or grant administrative capabilities must have compensating controls implemented to mitigate risk.
+
+**Description:**  
+When non-human identities require broad privileges for legitimate business purposes, organizations must implement defense-in-depth protections to reduce the risk of credential compromise or misuse. Compensating controls include IP address restrictions, OAuth scope limitations, activity monitoring and alerting, credential rotation policies, and dedicated identities per integration. Multiple compensating controls should be implemented based on the sensitivity of accessible data and the scope of granted permissions.
+
+**Rationale:**  
+Non-human identities with broad privileges represent high-value targets for attackers. Unlike human users, these identities typically use persistent credentials (API keys, OAuth tokens, certificates) that do not expire and are not protected by multi-factor authentication. Compensating controls create additional barriers to unauthorized access and enable detection of suspicious activity. Without these protections, a single compromised credential can result in complete data breach or system compromise.
+
+**Audit Procedure:**  
+1. Using the results from SBS-PERM-006, identify all non-human identities with broad privileges that have documented business justification
+2. For each privileged non-human identity, verify that at least two of the following compensating controls are implemented:
+   - **IP Address Restrictions:** Profile or permission set restricts login to specific IP ranges
+   - **OAuth Scope Limitations:** Connected app uses minimal OAuth scopes; refresh tokens have expiration
+   - **Activity Monitoring:** Automated monitoring alerts on unusual activity (off-hours access, high volume, geographic anomalies)
+   - **Credential Rotation:** Credentials are rotated at least every 90 days
+   - **Dedicated Identity:** Separate identity per integration (not shared across multiple systems)
+3. Verify that monitoring alerts are actively reviewed and responded to
+4. Confirm that compensating controls are documented in the justification for the privileged access
+
+**Remediation:**  
+1. For each privileged non-human identity, implement IP address restrictions in the assigned profile or permission set to limit access to known integration sources
+2. For OAuth-based integrations, configure connected apps with minimal required scopes and enable refresh token expiration
+3. Implement automated monitoring for privileged non-human identity activity using Event Monitoring, or third-party SSPM tools
+4. Establish credential rotation policies requiring API keys, passwords, and certificates to be rotated at least every 90 days
+5. Ensure each integration uses a dedicated non-human identity rather than sharing credentials across multiple systems
+6. Document all implemented compensating controls in the access justification
+
+**Default Value:**  
+Salesforce does not require or enforce compensating controls for privileged non-human identities. IP restrictions, OAuth scopes, monitoring, and credential rotation must be configured manually by administrators.

--- a/control-metadata/SBS-PERM-005.yaml
+++ b/control-metadata/SBS-PERM-005.yaml
@@ -1,0 +1,10 @@
+control_id: SBS-PERM-005
+
+remediation:
+  scope: entity
+  entity_type: User
+
+task:
+  title_template: "Remove broad privileges from non-human identity: {{entity.name}}"
+  
+  

--- a/control-metadata/SBS-PERM-005.yaml
+++ b/control-metadata/SBS-PERM-005.yaml
@@ -1,10 +1,8 @@
+# control-metadata/SBS-PERM-005.yaml
 control_id: SBS-PERM-005
 
 remediation:
-  scope: entity
-  entity_type: User
+  scope: inventory
 
 task:
-  title_template: "Remove broad privileges from non-human identity: {{entity.name}}"
-  
-  
+  title_template: "Establish and maintain inventory of non-human identities"

--- a/control-metadata/SBS-PERM-006.yaml
+++ b/control-metadata/SBS-PERM-006.yaml
@@ -1,0 +1,9 @@
+# control-metadata/SBS-PERM-006.yaml
+control_id: SBS-PERM-006
+
+remediation:
+  scope: entity
+  entity_type: User
+
+task:
+  title_template: "Remove broad privileges from non-human identity: {{entity.name}}"

--- a/control-metadata/SBS-PERM-007.yaml
+++ b/control-metadata/SBS-PERM-007.yaml
@@ -1,0 +1,9 @@
+# control-metadata/SBS-PERM-007.yaml
+control_id: SBS-PERM-007
+
+remediation:
+  scope: entity
+  entity_type: User
+
+task:
+  title_template: "Implement compensating controls for privileged non-human identity: {{entity.name}}"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -43,8 +43,14 @@ The "Approve Uninstalled Connected Apps" permission must only be assigned to hig
 **SBS-PERM-004: Documented Justification for All Super Admin–Equivalent Users**  
 All users with simultaneous View All Data, Modify All Data, and Manage Users permissions must be documented in a system of record with clear business or technical justification.
 
-**SBS-PERM-005: Restrict Broad Privileges for Non-Human Identities**  
-Non-human identities (integration users, automation users, bot users, and API-only accounts) must not be assigned permissions that bypass sharing rules or grant administrative capabilities without documented business justification and implemented compensating controls.
+**SBS-PERM-005: Maintain Inventory of Non-Human Identities**
+Organizations must maintain an authoritative inventory of all non-human identities, including integration users, automation users, bot users, and API-only accounts.
+
+**SBS-PERM-006: Restrict Broad Privileges for Non-Human Identities**
+Non-human identities must not be assigned permissions that bypass sharing rules or grant administrative capabilities unless documented business justification exists.
+
+**SBS-PERM-007: Implement Compensating Controls for Privileged Non-Human Identities**
+Non-human identities with permissions that bypass sharing rules or grant administrative capabilities must have compensating controls implemented to mitigate risk.
 
 ## Authentication
 
@@ -97,5 +103,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 24*
+*Total Controls: 27*
 

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -43,6 +43,9 @@ The "Approve Uninstalled Connected Apps" permission must only be assigned to hig
 **SBS-PERM-004: Documented Justification for All Super Admin–Equivalent Users**  
 All users with simultaneous View All Data, Modify All Data, and Manage Users permissions must be documented in a system of record with clear business or technical justification.
 
+**SBS-PERM-005: Restrict Broad Privileges for Non-Human Identities**  
+Non-human identities (integration users, automation users, bot users, and API-only accounts) must not be assigned permissions that bypass sharing rules or grant administrative capabilities without documented business justification and implemented compensating controls.
+
 ## Authentication
 
 **SBS-AUTH-001: Enforce Single Sign-On for All Standard Production Users**  


### PR DESCRIPTION
## Summary
This PR proposes three new controls to address non-human identity governance. Following maintainer feedback to ensure each control does "one thing," the original proposal has been split into three atomic controls that organizations can implement incrementally.

## What This Changes
- Adds SBS-PERM-005, SBS-PERM-006, and SBS-PERM-007 to the Permissions category
- Adds three controls to `benchmark/permissions.md`
- Creates metadata files: `control-metadata/SBS-PERM-005.yaml`, `control-metadata/SBS-PERM-006.yaml`, `control-metadata/SBS-PERM-007.yaml`
- Updates `controls-at-a-glance.md` with the three new controls
- Updates total control count from 24 to 27

## Security Gap This Addresses
Non-human identities (integration users, automation users, bot users, API-only accounts) are often granted broad privileges that bypass sharing rules or grant administrative capabilities without proper inventory, justification, or compensating controls. While SBS-PERM-004 addresses users with the specific combination of View All Data + Modify All Data + Manage Users simultaneously, these controls address non-human identities specifically with ANY broad privilege (including View All Data, Modify All Data, Author Apex, Customize Application, Modify Metadata, etc.). These identities operate without human oversight and use persistent credentials, creating significant security risk if over-privileged or compromised.

The three controls provide a progressive implementation path: establish inventory (PERM-005), remove unnecessary privileges (PERM-006), and protect remaining privileged access with compensating controls (PERM-007).

## Breaking Changes
None. These are new control additions and do not modify existing controls.
