### PR TITLE
Add optional dependencies metadata for controls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,8 @@ remediation:
   scope: entity  # Choose one: org, entity, mechanism, inventory
   entity_type: ConnectedApp  # only required if scope = entity
 
+dependencies: # Array of any control dependencies (e.g., optional features, external tooling)
+
 task:
   title_template: "Clear, actionable task description"
 ```
@@ -115,6 +117,11 @@ task:
 - If the control requires fixing each item individually → entity (and specify entity_type)
 - If the control requires building custom tooling or automation → mechanism
 - If the control requires maintaining external documentation/tracking → inventory
+
+**Dependencies:**
+
+- If the control depends upon any optional Salesforce features/add-ons and/or any external tooling
+
 
 **Task title templates:**
 

--- a/control-metadata/README.md
+++ b/control-metadata/README.md
@@ -13,6 +13,10 @@ remediation:
   scope: entity  # Choose one: org, entity, mechanism, inventory
   entity_type: <required only if scope = entity>
 
+dependencies:
+  - <dependency1>
+  - <dependency2>
+
 task:
   title_template: "<human-readable task title>"
 ```
@@ -22,7 +26,7 @@ task:
 1. **One remediation scope per control** - Each control must map to exactly one remediation shape
 2. **entity_type required for entity scope** - If `scope = entity`, `entity_type` must be specified
 3. **entity_type forbidden for other scopes** - Only `entity` scope may include `entity_type`
-4. **Optional metadata** - Controls without metadata files default to `scope = org` with no task title
+4. **Optional metadata** - Controls without metadata files default to `scope = org` with no task title and no dependencies
 5. **Atomic Control Rule** - If a control implies multiple obligations, it must be split into multiple controls
 
 ## Remediation Scopes


### PR DESCRIPTION
# Summary
This PR proposes adding a new, optional metadata key to track control dependencies on optional Salesforce features/add-ons and/or external tooling.

# What This Changes
Adds optional `dependencies` key to control metadata.

# Security Gap This Addresses

In the SBS Slack group there has been discussion around how to handle dependencies some controls may have on Salesforce features/add-ons and/or external tools. For example, there could be controls that are only made possible by Salesforce Shield. Baking assumptions into the framework that adopters will already have these features/add-ons/tools is not ideal, but excluding those controls from the framework entirely also seems wrong. By earmarking these dependencies in the control metadata we are able to still offer guidance to adopters that don't have the dependency (they can ignore or filter out controls dependent on Shield if they do not have it) as well as offer guidance to those that do have it.

# Breaking Changes
None. This is a new control metadata addition and does not modify existing controls.