### PR TITLE
Add SBS-CODE-004: Prevent Sensitive Data in Application Logs

### DIFF
--- a/benchmark/code-security.md
+++ b/benchmark/code-security.md
@@ -74,3 +74,94 @@ Salesforce debug logs are transient, size-limited, and automatically purged—ma
 **Default Value:**  
 Salesforce does not provide persistent application-level logging by default; debug logs are transient, size-limited, and automatically purged.
 
+### SBS-CODE-004: Prevent Sensitive Data in Application Logs
+
+**Control Statement:** Custom application logging frameworks and Salesforce system logging mechanisms must not capture, store, or transmit credentials, authentication tokens, personally identifiable information (PII), regulated data, or other sensitive values in log messages or structured log fields.
+
+**Description:**  
+Organizations must ensure that both custom Apex logging frameworks and Salesforce's built-in logging systems (debug logs, Event Monitoring, API usage logs) exclude sensitive data from all log outputs. This applies to:
+
+- Custom logging frameworks writing to custom objects or external systems
+- `System.debug()` statements that write to Salesforce debug logs
+- API callout logging captured in Event Monitoring
+- Error handling routines that log exception details
+
+Logging implementations must prevent the capture of:
+
+- Authentication credentials (passwords, API keys, client secrets, OAuth tokens, session IDs, refresh tokens)
+- Personally identifiable information (SSNs, passport numbers, driver's license numbers, tax IDs, account numbers)
+- Regulated financial data (credit card numbers, bank account details, routing numbers, CVV codes)
+- Protected health information (medical record numbers, diagnosis codes, treatment details)
+- Full SOQL query results containing sensitive fields (log record IDs or counts instead)
+- Request/response payloads containing authentication headers or authorization tokens
+- Unmasked field values from high-sensitivity objects (mask or tokenize before logging)
+
+Logging frameworks must provide sanitization functions that developers can invoke to remove or mask sensitive data before log events are persisted. Organizations must establish code review requirements that specifically check for sensitive data exposure in logging calls.
+
+**Risk:** <Badge type="danger" text="Critical" />  
+When application logs capture sensitive data, attackers who compromise low-privilege accounts with Read access to log storage objects can exfiltrate credentials, PII, or regulated data without triggering access controls on the original source objects. A single developer logging full request payloads "for debugging" creates a persistent secondary store of unprotected sensitive data accessible to anyone with object permissions—transforming a logging framework into a data leakage vector. This is especially severe in regulated industries: a compromised administrator querying log objects can extract thousands of customer records containing SSNs, account numbers, or health data in minutes. The organization's audit trail shows only "legitimate" queries against a custom logging object, making detection nearly impossible. During breach investigations, logs become evidence of regulatory violations (GDPR, GLBA, HIPAA) rather than forensic tools, triggering consent orders, third-party assessments, and multi-million fines.
+
+**Audit Procedure:**  
+1. Review all Apex classes to identify logging statements in both custom frameworks and `System.debug()` calls.  
+2. Examine log message construction to detect patterns that may capture sensitive data:
+   - Logging full SObject records or field values from high-sensitivity objects
+   - Logging request/response payloads without sanitization
+   - Logging query results or method parameters containing PII or credentials
+   - Concatenating user input directly into log messages without validation
+   - Using `System.debug()` with full object serialization or sensitive field values
+3. Query recent log records stored in custom objects and review Salesforce debug logs to inspect actual log content for sensitive data:
+   - Search for patterns matching SSNs, credit card numbers, email addresses, phone numbers
+   - Identify authentication tokens, session IDs, or API keys in log messages
+   - Flag any log records containing regulated data or PII
+4. Review Event Monitoring logs (if enabled) for API request/response bodies containing sensitive data.
+5. Verify that the logging framework provides and enforces sanitization functions for sensitive data.  
+6. Confirm that code review processes include checks for sensitive data exposure in all logging mechanisms.
+
+**Remediation:**  
+1. Implement sanitization utilities in custom logging frameworks and establish patterns for `System.debug()` calls:
+   ```apex
+   public class SecureLogger {
+       public static void logInfo(String message, Map<String, Object> context) {
+           // Sanitize context before logging
+           Map<String, Object> sanitized = sanitizeContext(context);
+           Logger.info(message, sanitized);
+       }
+       
+       private static Map<String, Object> sanitizeContext(Map<String, Object> ctx) {
+           Map<String, Object> result = new Map<String, Object>();
+           for (String key : ctx.keySet()) {
+               // Mask sensitive fields, log IDs instead of full records
+               if (key.containsIgnoreCase('password') || 
+                   key.containsIgnoreCase('token') || 
+                   key.containsIgnoreCase('ssn')) {
+                   result.put(key, '***REDACTED***');
+               } else if (ctx.get(key) instanceof SObject) {
+                   result.put(key, ((SObject)ctx.get(key)).Id);
+               } else {
+                   result.put(key, ctx.get(key));
+               }
+           }
+           return result;
+       }
+   }
+   ```
+2. Audit existing log records in custom objects and purge Salesforce debug logs containing sensitive data.  
+3. Update all logging calls to use sanitization functions and avoid logging sensitive data:
+   ```apex
+   // BAD - logs full account with SSN field
+   System.debug('Processing: ' + acc);
+   Logger.info('Processing account', new Map<String, Object>{'account' => acc});
+   
+   // GOOD - logs only record ID
+   System.debug('Processing account: ' + acc.Id);
+   SecureLogger.logInfo('Processing account', new Map<String, Object>{
+       'accountId' => acc.Id,
+       'recordCount' => 1
+   });
+   ```
+4. Establish automated testing that validates log outputs do not contain sensitive data patterns.  
+5. Add logging security checks to peer review and static analysis workflows.  
+6. Disable or restrict Event Monitoring features that capture full API request/response bodies in regulated environments.
+
+**Default Value:**  
+Salesforce does not prevent or sanitize sensitive data in custom application logs or system debug logs; developers bear full responsibility for ensuring log content complies with data protection requirements.

--- a/benchmark/code-security.md
+++ b/benchmark/code-security.md
@@ -79,11 +79,10 @@ Salesforce does not provide persistent application-level logging by default; deb
 **Control Statement:** Custom application logging frameworks and Salesforce system logging mechanisms must not capture, store, or transmit credentials, authentication tokens, personally identifiable information (PII), regulated data, or other sensitive values in log messages or structured log fields.
 
 **Description:**  
-Organizations must ensure that both custom Apex logging frameworks and Salesforce's built-in logging systems (debug logs, Event Monitoring, API usage logs) exclude sensitive data from all log outputs. This applies to:
+Organizations must ensure that custom Apex logging frameworks and Salesforce debug logs exclude sensitive data from all log outputs. This applies to:
 
 - Custom logging frameworks writing to custom objects or external systems
 - `System.debug()` statements that write to Salesforce debug logs
-- API callout logging captured in Event Monitoring
 - Error handling routines that log exception details
 
 Logging implementations must prevent the capture of:

--- a/control-metadata/SBS-CODE-004.yaml
+++ b/control-metadata/SBS-CODE-004.yaml
@@ -1,0 +1,9 @@
+control_id: SBS-CODE-004
+risk_level: Critical
+
+remediation:
+  scope: entity
+  entity_type: Logging Statement
+
+task:
+  title_template: "Sanitize sensitive data in {{entity.name}} logging call"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -92,6 +92,9 @@ Static code analysis with security checks for Apex and Lightning Web Components 
 **SBS-CODE-003: Implement Persistent Apex Application Logging**  
 Organizations must implement an Apex-based logging framework that writes application log events to durable Salesforce storage and must not rely on transient Salesforce debug logs for operational or security investigations.
 
+**SBS-CODE-004: Prevent Sensitive Data in Application Logs**  
+Application logging frameworks must not capture, store, or transmit credentials, authentication tokens, personally identifiable information (PII), regulated data, or other sensitive values in log messages or structured log fields.
+
 ## Customer Portals
 
 **SBS-CPORTAL-001: Prevent Parameter-Based Record Access in Portal Apex**  


### PR DESCRIPTION
Adds new control addressing data leakage through logging frameworks - a common vulnerability in financial services and regulated industries.

## What's New
- **SBS-CODE-004**: Prevent Sensitive Data in Application Logs (Critical risk)
- Covers both custom Apex logging frameworks AND Salesforce system logs (System.debug(), Event Monitoring)
- Prevents logging of credentials, PII, SSNs, tokens, regulated financial/health data