### PR TITLE
Add SBS-ACS-012: Restrict Login Hours for Privileged Permissions

### DIFF
--- a/benchmark/access-controls.md
+++ b/benchmark/access-controls.md
@@ -377,24 +377,26 @@ Without enforced governance over access changes, organizations lose visibility a
 **Default Value:**  
 Salesforce does not enforce approval workflows or governance for access and authorization changes. Administrators can directly modify users, permissions, roles, and sharing settings without documented approval or justification. While certain changes may appear in audit logs, governance enforcement is dependent on organizational policy and external processes.
 
-### SBS-ACS-012: Restrict Login Hours for Privileged Permissions
+### SBS-ACS-012: Classify Users for Login Hours Restrictions
 
-**Control Statement:** Users with administrative permissions or access to sensitive data must have login hours configured that restrict authentication to business hours.
+**Control Statement:** Organizations must maintain a documented classification of users requiring login hours restrictions or equivalent off-hours authentication monitoring.
 
 **Description:**  
-Organizations must configure login hours that limit when privileged users can authenticate to Salesforce, based on expected business activity patterns.
+Organizations must perform risk-based classification to identify users for whom off-hours authentication poses elevated security risk. For each classified user, organizations must either configure login hours restrictions on their profile or implement monitoring and alerting for off-hours authentication. Organizations may classify zero users if documented and reviewed periodically.
 
 **Risk:** <Badge type="tip" text="Moderate" />  
-Without login hours restrictions, privileged accounts can authenticate at any time—including off-hours when compromise is more likely to go undetected. Login hours provide defense-in-depth by limiting the window during which compromised credentials can be exploited. However, this control requires credential compromise for exploitation and does not establish a primary security boundary; authentication controls (SBS-AUTH-001) remain the primary protection.
+When privileged accounts authenticate without time restrictions or monitoring, compromised credentials can be exploited during off-hours when detection is less likely. Login hours or monitoring provides defense-in-depth by limiting attack windows or enabling investigation. However, this requires credential compromise and does not establish a primary boundary—authentication controls (SBS-AUTH-001) and IP restrictions (SBS-AUTH-003) remain primary protections.
 
 **Audit Procedure:**  
-1. Identify users with administrative permissions or access to sensitive data.  
-2. Verify each privileged user has login hours configured.  
-3. Flag users with unrestricted (24x7) login hours as noncompliant.
+1. Verify the organization maintains a documented classification identifying users requiring login hours restrictions or monitoring.  
+2. For classified users, verify login hours are configured or off-hours authentication monitoring is implemented.  
+3. If zero users are classified, verify this decision is documented with justification and reviewed periodically.
 
 **Remediation:**  
-1. Configure login hours for privileged users to match business hours.  
-2. Review login hours during periodic access reviews.
+1. Perform risk-based user classification based on privileges and data access.  
+2. For classified users, either configure login hours on profiles or implement off-hours authentication monitoring with alerting.  
+3. Document classification and implementation decisions in a system of record.  
+4. Review during periodic access reviews (SBS-ACS-010).
 
 **Default Value:**  
-Salesforce does not enforce login hours restrictions by default; users can authenticate 24x7 unless explicitly configured.
+Salesforce does not enforce login hours or monitor off-hours authentication by default; users can authenticate 24x7 unless explicitly configured.

--- a/benchmark/access-controls.md
+++ b/benchmark/access-controls.md
@@ -376,3 +376,25 @@ Without enforced governance over access changes, organizations lose visibility a
 
 **Default Value:**  
 Salesforce does not enforce approval workflows or governance for access and authorization changes. Administrators can directly modify users, permissions, roles, and sharing settings without documented approval or justification. While certain changes may appear in audit logs, governance enforcement is dependent on organizational policy and external processes.
+
+### SBS-ACS-012: Restrict Login Hours for Privileged Permissions
+
+**Control Statement:** Users with administrative permissions or access to sensitive data must have login hours configured that restrict authentication to business hours.
+
+**Description:**  
+Organizations must configure login hours that limit when privileged users can authenticate to Salesforce, based on expected business activity patterns.
+
+**Risk:** <Badge type="tip" text="Moderate" />  
+Without login hours restrictions, privileged accounts can authenticate at any time—including off-hours when compromise is more likely to go undetected. Login hours provide defense-in-depth by limiting the window during which compromised credentials can be exploited. However, this control requires credential compromise for exploitation and does not establish a primary security boundary; authentication controls (SBS-AUTH-001) remain the primary protection.
+
+**Audit Procedure:**  
+1. Identify users with administrative permissions or access to sensitive data.  
+2. Verify each privileged user has login hours configured.  
+3. Flag users with unrestricted (24x7) login hours as noncompliant.
+
+**Remediation:**  
+1. Configure login hours for privileged users to match business hours.  
+2. Review login hours during periodic access reviews.
+
+**Default Value:**  
+Salesforce does not enforce login hours restrictions by default; users can authenticate 24x7 unless explicitly configured.

--- a/control-metadata/SBS-ACS-012.yaml
+++ b/control-metadata/SBS-ACS-012.yaml
@@ -1,9 +1,6 @@
 control_id: SBS-ACS-012
 risk_level: Moderate
-
 remediation:
-  scope: entity
-  entity_type: Profile
-
+  scope: inventory
 task:
-  title_template: "Configure login hours for {{entity.name}}"
+  title_template: "Establish and maintain user classification for login hours restrictions"

--- a/control-metadata/SBS-ACS-012.yaml
+++ b/control-metadata/SBS-ACS-012.yaml
@@ -1,0 +1,9 @@
+control_id: SBS-ACS-012
+risk_level: Moderate
+
+remediation:
+  scope: entity
+  entity_type: Profile
+
+task:
+  title_template: "Configure login hours for {{entity.name}}"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -67,8 +67,8 @@ All user access and configuration influencing permissions and sharing must be fo
 **SBS-ACS-011: Enforce Governance of Access and Authorization Changes**  
 All changes to Salesforce user access and authorization must be governed through a documented process that requires approval, records business justification, and produces an auditable record of the change.
 
-**SBS-ACS-012: Restrict Login Hours for Privileged Permissions**  
-Users with administrative permissions or access to sensitive data must have login hours configured that restrict authentication to business hours.
+**SBS-ACS-012: Classify Users for Login Hours Restrictions**  
+Organizations must maintain a documented classification of users who require login hours restrictions or equivalent monitoring, and must either enforce those restrictions or implement monitoring and alerting for off-hours authentication.
 
 ## Authentication
 

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -67,6 +67,9 @@ All user access and configuration influencing permissions and sharing must be fo
 **SBS-ACS-011: Enforce Governance of Access and Authorization Changes**  
 All changes to Salesforce user access and authorization must be governed through a documented process that requires approval, records business justification, and produces an auditable record of the change.
 
+**SBS-ACS-012: Restrict Login Hours for Privileged Permissions**  
+Users with administrative permissions or access to sensitive data must have login hours configured that restrict authentication to business hours.
+
 ## Authentication
 
 **SBS-AUTH-001: Enforce Single Sign-On for All Standard Production Users**  


### PR DESCRIPTION
Adds binary defense-in-depth control for restricting privileged user authentication windows.

## What's New
- **SBS-ACS-012**: Restrict Login Hours for Privileged Permissions (Moderate risk)
- Limits authentication windows for users with administrative or sensitive data access