### PR TITLE
Add SBS-CPORTAL-003: Enable Clickjack Protection

### DIFF
--- a/benchmark/customer-portals.md
+++ b/benchmark/customer-portals.md
@@ -99,3 +99,27 @@ Guest users represent the highest-risk trust boundary in Salesforce portals—th
 
 **Default Value:**  
 Salesforce has progressively restricted guest user default permissions in recent releases, but older orgs may retain permissive configurations. Guest user profiles do not prevent object access or Apex invocation by default—administrators must explicitly configure restrictions.
+
+### SBS-CPORTAL-003: Enable Clickjack Protection
+
+**Control Statement:** All Experience Cloud sites must enable clickjack protection at "Allow framing by the same origin only" or "Don't allow framing" level.
+
+**Description:**  
+Organizations must configure clickjack protection for all Experience Cloud sites (Communities, customer portals, partner portals) to prevent malicious sites from embedding site pages in hidden iframes. Clickjacking attacks trick authenticated users into performing unintended actions by overlaying transparent or opaque layers over legitimate site content. Protection must be set to "Allow framing by the same origin only" (recommended default) or "Don't allow framing" (most restrictive). If business requirements necessitate external framing, the "Allow framing by specific external domains" option must document a justified list of trusted domains with change control.
+
+**Risk:** <Badge type="warning" text="Moderate" />  
+Clickjacking requires both a misconfigured protection setting and user action (visiting an attacker-controlled site while authenticated), making it a defense-in-depth control rather than a direct vulnerability. However, when protection is disabled or external framing is enabled without proper domain governance, attackers can embed site pages in malicious contexts and trick users into submitting forms, clicking buttons, or modifying data through UI manipulation. This is particularly effective against high-value targets (administrators, privileged users) who may be targeted via phishing campaigns. While not a Critical boundary violation, it represents a measurable increase in attack surface when disabled.
+
+**Audit Procedure:**  
+1. Navigate to **Setup → All Sites** and review all Experience Cloud sites.  
+2. For each site, access **Builder → Settings → Security & Privacy** and verify the clickjack protection level.  
+3. Flag sites configured with "Allow framing by any page" as noncompliant.  
+4. For sites using "Allow framing by specific external domains," verify that trusted domains are documented, justified, and subject to change control.
+
+**Remediation:**  
+1. Navigate to **Setup → All Sites**, select the site, and access **Builder → Settings → Security & Privacy**.  
+2. Set clickjack protection to "Allow framing by the same origin only" (recommended) or "Don't allow framing" for maximum protection.  
+3. If external framing is required, select "Allow framing by specific external domains," document the business justification for each domain, and implement change control for modifications.
+
+**Default Value:**  
+Salesforce Experience Cloud sites default to "Allow framing by the same origin only" which provides appropriate protection.

--- a/control-metadata/SBS-CPORTAL-003.yaml
+++ b/control-metadata/SBS-CPORTAL-003.yaml
@@ -1,0 +1,7 @@
+control_id: SBS-CPORTAL-003
+risk_level: Moderate
+remediation:
+  scope: entity
+  entity_type: Experience Cloud Site
+task:
+  title_template: "Enable clickjack protection for {{entity.name}}"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -100,6 +100,9 @@ AuraEnabled methods exposed to customer portal users must not accept user-suppli
 **SBS-CPORTAL-002: Restrict Guest User Record Access**  
 Guest users in customer portals must not have Create, Read, Update, or Delete permissions on standard or custom objects except as strictly required for unauthenticated user flows.
 
+**SBS-CPORTAL-003: Enable Clickjack Protection**  
+All Experience Cloud sites must enable clickjack protection at "Allow framing by the same origin only" or "Don't allow framing" level.
+
 ## Data Security
 
 **SBS-DATA-001: Implement Mechanisms to Detect Regulated Data in Long Text Area Fields**  
@@ -132,5 +135,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 34*
+*Total Controls: 39*
 


### PR DESCRIPTION
## Summary

Adds a new control requiring clickjack protection for Experience Cloud sites.

## Changes

- Add CPORTAL-003 control to customer-portals.md requiring clickjack protection at 'same origin only' or 'no framing' level
- Create control metadata YAML (Moderate risk, entity scope)
- Update controls-at-a-glance.md with CPORTAL-003 summary
- Update total controls count from 34 to 39