### PR TITLE
Adds a new SBS-DATA-003 control requiring documented backup and recovery for Salesforce data and metadata, with scheduled restoration testing.

### DIFF
--- a/benchmark/data-security.md
+++ b/benchmark/data-security.md
@@ -54,3 +54,28 @@ Without a current inventory of fields containing regulated data, organizations c
 
 **Default Value:**  
 Salesforce does not maintain or provide an inventory of Long Text Area fields containing regulated data.
+
+### SBS-DATA-003: Maintain Tested Backup and Recovery for Salesforce Data and Metadata
+
+**Control Statement:** Salesforce production orgs must maintain a documented backup and recovery capability for Salesforce data and metadata, and must test restoration on a defined schedule.
+
+**Description:**  
+Organizations must back up Salesforce data and metadata using Salesforce exports, APIs, source control, or third-party tooling, and must document recovery procedures sufficient to restore a known-good state.
+
+**Risk:** <Badge type="warning" text="High" />  
+Without reliable backups and tested restoration procedures, organizations cannot recover from accidental deletion, malicious data destruction, configuration corruption, or ransomware-like events. This impairs incident response, business continuity, and the ability to validate data integrity after security events or outages.
+
+**Audit Procedure:**  
+1. Obtain the documented backup and recovery policy covering Salesforce data and metadata.  
+2. Verify that backups are performed on a defined schedule and retained per policy.  
+3. Review evidence of a completed restoration test within the defined testing interval.  
+4. Confirm that backup storage is protected with appropriate access controls.
+
+**Remediation:**  
+1. Implement or configure a backup solution for Salesforce data and metadata.  
+2. Define backup frequency, retention, and storage protections.  
+3. Execute and document restoration tests on the defined schedule.  
+4. Update recovery procedures based on test results.
+
+**Default Value:**  
+Salesforce does not provide automatic, comprehensive backup and restore for all data and metadata by default.

--- a/control-metadata/SBS-DATA-003.yaml
+++ b/control-metadata/SBS-DATA-003.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-DATA-003
+risk_level: High
+
+remediation:
+  scope: mechanism
+
+task:
+  title_template: "Implement and test Salesforce backup and recovery capability"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -108,6 +108,9 @@ The organization must implement a mechanism that continuously or periodically an
 **SBS-DATA-002: Maintain an Inventory of Long Text Area Fields Containing Regulated Data**  
 The organization must maintain an up-to-date inventory of all Long Text Area fields that are known or detected to contain regulated or personal data.
 
+**SBS-DATA-003: Maintain Tested Backup and Recovery for Salesforce Data and Metadata**  
+Salesforce production orgs must maintain a documented backup and recovery capability for Salesforce data and metadata, and must test restoration on a defined schedule.
+
 ## Deployments
 
 **SBS-DEP-001: Require a Designated Deployment Identity for Metadata Changes**  
@@ -132,5 +135,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 34*
+*Total Controls: 35*
 


### PR DESCRIPTION
## Summary

Adds a new SBS-DATA-003 control requiring documented backup and recovery for Salesforce data and metadata, with scheduled restoration testing.

## Changes

- Add SBS-DATA-003 control to data-security.md for backup and recovery requirements
- Create control metadata YAML (High risk, mechanism scope)
- Update controls-at-a-glance.md with SBS-DATA-003 summary and increment total controls count from 34 to 35