### PR TITLE
Adds a new SBS-DATA-004 control requiring Field History Tracking for all designated sensitive fields.

### DIFF
--- a/benchmark/data-security.md
+++ b/benchmark/data-security.md
@@ -54,3 +54,27 @@ Without a current inventory of fields containing regulated data, organizations c
 
 **Default Value:**  
 Salesforce does not maintain or provide an inventory of Long Text Area fields containing regulated data.
+
+### SBS-DATA-004: Require Field History Tracking for Sensitive Fields
+
+**Control Statement:** The organization must maintain a documented list of sensitive fields and ensure Field History Tracking is enabled for each listed field on all in-scope objects.
+
+**Description:**  
+Organizations must define which fields are sensitive (e.g., regulated data, financial identifiers, or security-relevant attributes) and enable Field History Tracking for those fields so changes can be audited. Any sensitive field without tracking is noncompliant.
+
+**Risk:** <Badge type="warning" text="High" />  
+Without field history tracking on sensitive fields, unauthorized or accidental changes cannot be reliably detected or investigated. This reduces auditability, impairs incident response, and weakens accountability for changes to regulated or high-impact data.
+
+**Audit Procedure:**  
+1. Obtain the organization’s documented list of sensitive fields and in-scope objects.  
+2. Enumerate Field History Tracking settings for those objects.  
+3. Verify that each listed sensitive field has Field History Tracking enabled.  
+4. Flag any sensitive field without tracking.
+
+**Remediation:**  
+1. Enable Field History Tracking for all listed sensitive fields.  
+2. Update the sensitive-field list as schemas evolve.  
+3. Re-verify tracking coverage after changes.
+
+**Default Value:**  
+Salesforce does not enable Field History Tracking for sensitive fields by default.

--- a/control-metadata/SBS-DATA-004.yaml
+++ b/control-metadata/SBS-DATA-004.yaml
@@ -1,0 +1,9 @@
+control_id: SBS-DATA-004
+risk_level: High
+
+remediation:
+  scope: entity
+  entity_type: FieldDefinition
+
+task:
+  title_template: "Enable field history tracking for sensitive field: {{entity.name}}"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -108,6 +108,9 @@ The organization must implement a mechanism that continuously or periodically an
 **SBS-DATA-002: Maintain an Inventory of Long Text Area Fields Containing Regulated Data**  
 The organization must maintain an up-to-date inventory of all Long Text Area fields that are known or detected to contain regulated or personal data.
 
+**SBS-DATA-004: Require Field History Tracking for Sensitive Fields**  
+The organization must maintain a documented list of sensitive fields and ensure Field History Tracking is enabled for each listed field on all in-scope objects.
+
 ## Deployments
 
 **SBS-DEP-001: Require a Designated Deployment Identity for Metadata Changes**  
@@ -132,5 +135,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 34*
+*Total Controls: 35*
 


### PR DESCRIPTION
## Summary

Adds a new SBS-DATA-004 control requiring Field History Tracking for all designated sensitive fields.

## Changes

- Add SBS-DATA-004 control to data-security.md for sensitive field history tracking
- Create control metadata YAML (High risk, entity scope: FieldDefinition)
- Update controls-at-a-glance.md with SBS-DATA-004 summary and increment total controls count from 34 to 35