### PR TITLE
Adds a new SBS-FDNS-002 control requiring a documented, periodically reviewed Salesforce exit plan.

### DIFF
--- a/benchmark/foundations.md
+++ b/benchmark/foundations.md
@@ -28,3 +28,27 @@ A formally maintained system of record is foundational for ensuring repeatable, 
 
 **Default Value:**  
 Salesforce does not provide or require a system of record for documenting security-relevant metadata, exceptions, or justifications.
+
+### SBS-FDNS-002: Document and Maintain a Salesforce Exit Plan
+
+**Control Statement:** The organization must maintain a documented Salesforce exit plan that defines how data, metadata, integrations, and business processes would be migrated or decommissioned.
+
+**Description:**  
+Organizations must maintain a current exit plan that includes data export and retention requirements, metadata migration approach, integration dependencies, ownership, and cutover/rollback strategy. The plan must be reviewed on a defined schedule and updated after material architectural or integration changes.
+
+**Risk:** <Badge type="tip" text="Moderate" />  
+Without a documented exit plan, organizations risk data loss, extended downtime, and uncontrolled exposure during platform transitions, contract termination, or major incidents requiring rapid migration.
+
+**Audit Procedure:**  
+1. Obtain the documented Salesforce exit plan.  
+2. Verify the plan includes data export/retention, metadata migration, integration dependencies, ownership, and cutover/rollback steps.  
+3. Confirm the review schedule and evidence of the most recent review.  
+4. Flag noncompliance if any required section is missing or the plan is outdated.
+
+**Remediation:**  
+1. Create and document the exit plan with required sections.  
+2. Assign ownership and define a review cadence.  
+3. Update the plan after major system or integration changes.
+
+**Default Value:**  
+Salesforce does not provide an organization-specific exit plan by default.

--- a/control-metadata/SBS-FDNS-002.yaml
+++ b/control-metadata/SBS-FDNS-002.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-FDNS-002
+risk_level: Moderate
+
+remediation:
+  scope: inventory
+
+task:
+  title_template: "Establish and maintain Salesforce exit plan"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -7,6 +7,9 @@ This page provides a quick reference to all SBS control statements. Each control
 **SBS-FDNS-001: Centralized Security System of Record**  
 The organization must maintain a centralized system of record documenting all Salesforce security configurations, exceptions, justifications, and SBS-required inventories.
 
+**SBS-FDNS-002: Document and Maintain a Salesforce Exit Plan**  
+The organization must maintain a documented Salesforce exit plan that defines how data, metadata, integrations, and business processes would be migrated or decommissioned.
+
 ## OAuth Security
 
 **SBS-OAUTH-001: Require Formal Installation and Access Governance for Connected Apps**  
@@ -132,5 +135,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 34*
+*Total Controls: 35*
 


### PR DESCRIPTION
## Summary

Adds a new SBS-FDNS-002 control requiring a documented, periodically reviewed Salesforce exit plan.

## Changes

- Add SBS-FDNS-002 control to foundations.md defining required exit plan sections and review cadence
- Create control metadata YAML (Moderate risk, inventory scope)
- Update controls-at-a-glance.md with SBS-FDNS-002 summary and increment total controls count from 34 to 35