### PR TITLE
Adds SBS-CPORTAL-006 & SBS-CPORTAL-007: Preventing Data Leaks from Digital Experience Sites

### DIFF
--- a/benchmark/customer-portals.md
+++ b/benchmark/customer-portals.md
@@ -225,12 +225,12 @@ Organizations must:
 * Review external sharing settings when new objects are created or when sharing configuration changes.
 
 **Risk:** <Badge type="danger" text="Critical" />
-When external OWDs are set to Public Read Only, every authenticated portal user can read every record of that object across the entire org. A single portal user with legitimate credentials can access the complete dataset—including records belonging to other customers, partners, or internal teams. This cross-tenant data exposure is especially damaging in multi-customer portals where isolation between portal users is a business requirement. Combined with API access (SBS-CPORTAL-006), an attacker can script bulk extraction of all records in any object with permissive external sharing. This constitutes a Critical data isolation failure.
+When external OWDs are set to Public Read Only, every authenticated portal user can read every record of that object across the entire org. A single portal user with legitimate credentials can access the complete dataset—including records belonging to other customers, partners, or internal teams. This cross-tenant data exposure is especially damaging in multi-customer portals where isolation between portal users is a business requirement. Combined with SBS-CPORTAL-006, an attacker can script bulk extraction of all records in any object with permissive external sharing. This constitutes a Critical data isolation failure.
 
 **Audit Procedure:**
 1. Navigate to Setup > Sharing Settings and review the Organization-Wide Defaults for all objects.
 2. Identify objects where the external access level is set to Public Read Only or Public Read/Write.
-3. For each object with a non-Private external OWD, determine whether external portal users have profile-level access to the object.
+3. For each object with a non-Private external OWD, determine whether external portal users have access to the object via profile or permission set.
 4. Verify whether a documented business justification and compensating controls exist for any non-Private external OWD.
 5. Test by authenticating as a portal user and querying records owned by other users or accounts.
 6. Flag any object with a non-Private external OWD and portal user access that lacks documented justification as noncompliant.

--- a/benchmark/customer-portals.md
+++ b/benchmark/customer-portals.md
@@ -176,7 +176,7 @@ Salesforce does not require or conduct penetration testing of customer implement
 ### SBS-CPORTAL-006: Minimize Object and Field Permissions for Authenticated Portal User Profiles and Permission Sets
 
 **Control Statement:**
-Authenticated portal user profiles and permission sets must restrict object-level (CRUD) and field-level (FLS) permissions to only those objects and fields required for portal functionality. Objects not used by any portal component must have all permissions removed from external user profiles and permission sets.
+Authenticated portal user profiles and permission sets must only provide object-level (CRUD) and field-level (FLS) permissions to those objects and fields required for portal functionality. Objects not used by any portal component must have all permissions removed from external user profiles and permission sets.
 
 **Description:**
 When an external user authenticates to an Experience Cloud site, their profile and permission sets determine which objects and fields they can access—not only through the portal UI, but also through Salesforce's standard Aura components that underpin Digital Experience sites. These built-in components (such as those powering record detail pages, list views, and related lists) respect object-level and field-level permissions but do not restrict access to only the objects explicitly placed on portal pages. Any object with Read access granted to a portal user profile or permission set can be queried through standard Aura component requests, even if no portal page or custom component references that object. This creates a hidden data exposure surface that is invisible to administrators reviewing portal pages alone.

--- a/benchmark/customer-portals.md
+++ b/benchmark/customer-portals.md
@@ -140,5 +140,35 @@ Flows accepting user-controlled input variables for record access create IDOR vu
 2. Derive accessible records from authenticated user context (e.g., `$User.Id`, `$User.ContactId`, `$User.AccountId`).
 3. Configure flows to run in user context ("With Sharing") where available.
 
-**Default Value:**  
+**Default Value:**
 Salesforce does not prevent flows from accepting user-supplied input variables. Autolaunched Flows run in system context without sharing by default.
+
+### SBS-CPORTAL-005: Conduct Penetration Testing for Portal Security
+
+**Control Statement:** Organizations with Experience Cloud sites must conduct penetration testing of portal security controls before initial go-live and subsequently after major releases or on a defined cadence.
+
+**Description:**
+Penetration testing validates that authentication boundaries, authorization controls, and data access restrictions function correctly under adversarial conditions. Testing must target portal-exposed Apex classes, Flows, and components, including parameter manipulation, IDOR attempts, and privilege escalation scenarios. Organizations determine ongoing testing frequency based on regulatory requirements and change velocity.
+
+**Risk:** <Badge type="warning" text="High" />
+Without regular penetration testing, organizations cannot verify that portal security controls function correctly when adversaries attempt to exploit them. Configuration audits verify settings exist but cannot validate runtime behavior under attack. Undetected vulnerabilities in portal-exposed components allow unauthorized data access.
+
+**Audit Procedure:**
+1. Verify penetration testing was conducted before initial portal go-live.
+2. Verify the organization has defined an ongoing testing cadence based on regulatory requirements and change frequency.
+3. Request documentation of the most recent portal penetration test.
+4. Verify testing occurred according to the defined cadence or after major releases.
+5. Confirm test scope included portal-exposed Apex classes and Flows.
+6. Review test report for identified vulnerabilities and remediation status.
+7. Flag as noncompliant if no go-live testing occurred, ongoing testing does not follow the defined cadence, or if high/critical findings remain unremediated.
+
+**Remediation:**
+1. Conduct penetration testing before initial portal go-live.
+2. Define ongoing testing cadence based on regulatory requirements and release frequency.
+3. Engage qualified penetration testers with Salesforce Experience Cloud expertise.
+4. Define test scope covering all portal-exposed components.
+5. Conduct testing according to defined cadence and after major portal changes.
+6. Remediate identified vulnerabilities before production deployment.
+
+**Default Value:**
+Salesforce does not require or conduct penetration testing of customer implementations.

--- a/control-metadata/SBS-CPORTAL-006.yaml
+++ b/control-metadata/SBS-CPORTAL-006.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-CPORTAL-006
+risk_level: Critical
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Remove unnecessary object and field permissions from portal user profiles and permission sets"

--- a/control-metadata/SBS-CPORTAL-007.yaml
+++ b/control-metadata/SBS-CPORTAL-007.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-CPORTAL-007
+risk_level: Critical
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Set external Organization-Wide Defaults to Private for portal-accessible objects"

--- a/control-metadata/SBS-FDNS-001.yaml
+++ b/control-metadata/SBS-FDNS-001.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-FDNS-001
+risk_level: High
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Establish centralized security system of record for Salesforce governance"

--- a/control-metadata/SBS-FILE-001.yaml
+++ b/control-metadata/SBS-FILE-001.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-FILE-001
+risk_level: Moderate
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Enforce expiry dates on all Public Content links"

--- a/control-metadata/SBS-FILE-002.yaml
+++ b/control-metadata/SBS-FILE-002.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-FILE-002
+risk_level: High
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Enforce passwords on Public Content links for sensitive content"

--- a/control-metadata/SBS-FILE-003.yaml
+++ b/control-metadata/SBS-FILE-003.yaml
@@ -1,0 +1,8 @@
+control_id: SBS-FILE-003
+risk_level: Moderate
+
+remediation:
+  scope: org
+
+task:
+  title_template: "Implement periodic review and cleanup of Public Content links"

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -85,6 +85,12 @@ Autolaunched Flows exposed to customer portal users must not accept user-supplie
 **SBS-CPORTAL-005: Conduct Penetration Testing for Portal Security**
 Organizations with Experience Cloud sites must conduct penetration testing of portal security controls before initial go-live and subsequently after major releases or on a defined cadence.
 
+**SBS-CPORTAL-006: Minimize Object and Field Permissions for Authenticated Portal User Profiles and Permission Sets**
+Authenticated portal user profiles and permission sets must restrict object-level (CRUD) and field-level (FLS) permissions to only those objects and fields required for portal functionality. Objects not used by any portal component must have all permissions removed from external user profiles and permission sets.
+
+**SBS-CPORTAL-007: Restrict External Organization-Wide Default Sharing Settings**
+External Organization-Wide Default (OWD) sharing settings must be set to Private for all objects containing sensitive or internal data accessible by portal users. Objects must not use Public Read Only or Public Read/Write external sharing defaults unless a documented business justification exists and compensating controls are in place.
+
 ## Data Security
 
 **SBS-DATA-001: Implement Mechanisms to Detect Regulated Data in Long Text Area Fields**
@@ -173,4 +179,4 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 49*
+*Total Controls: 51*

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -9,13 +9,16 @@ The organization must maintain a centralized system of record documenting all Sa
 
 ## OAuth Security
 
-**SBS-OAUTH-001: Require Formal Installation and Access Governance for Connected Apps**  
-Organizations must formally install all connected apps and must control access to each installed app exclusively through assigned profiles or permission sets.
+**SBS-OAUTH-001: Require Formal Installation of Connected Apps**
+Organizations must formally install all connected apps used for OAuth authentication rather than relying on user-authorized OAuth connections.
 
-**SBS-OAUTH-002: Inventory and Criticality Classification of OAuth-Enabled Connected Apps**  
+**SBS-OAUTH-002: Require Profile or Permission Set Access Control for Connected Apps**
+Organizations must control access to each formally installed connected app exclusively through assigned profiles or permission sets.
+
+**SBS-OAUTH-003: Add Criticality Classification of OAuth-Enabled Connected Apps**
 All OAuth-enabled Connected Apps must be recorded in an authoritative system of record and assigned a documented vendor criticality rating reflecting integration importance and data sensitivity.
 
-**SBS-OAUTH-003: Due Diligence Documentation for High-Risk Connected App Vendors**  
+**SBS-OAUTH-004: Due Diligence Documentation for High-Risk Connected App Vendors**
 Organizations must review and retain available security documentation for all high-risk Connected App vendors and explicitly record any missing documentation as part of the vendor assessment.
 
 ## Integrations
@@ -170,5 +173,5 @@ Salesforce production orgs must periodically review Health Check results against
 
 ---
 
-*Total Controls: 45*
+*Total Controls: 49*
 

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -2,10 +2,152 @@
 
 This page provides a quick reference to all SBS control statements. Each control statement is a concise, single-sentence summary of the requirement. For full details including rationale, audit procedures, and remediation steps, refer to the individual control sections.
 
+## Access Controls
+
+**SBS-ACS-001: Enforce a Documented Permission Set Model**
+All permission sets, permission set groups, and profiles must conform to a documented model maintained in a system of record and enforced continuously.
+
+**SBS-ACS-002: Documented Justification for All `API-Enabled` Authorizations**
+Every authorization granting the "API Enabled" permission must have documented business or technical justification recorded in a system of record.
+
+**SBS-ACS-003: Documented Justification for `Approve Uninstalled Connected Apps` Permission**
+The "Approve Uninstalled Connected Apps" permission must only be assigned to highly trusted users with documented justification and must not be granted to end-users.
+
+**SBS-ACS-004: Documented Justification for All Super Admin–Equivalent Users**
+All users with simultaneous View All Data, Modify All Data, and Manage Users permissions must be documented in a system of record with clear business or technical justification.
+
+**SBS-ACS-005: Only Use Custom Profiles for Active Users**
+All active users must be assigned custom profiles. The out-of-the-box standard profiles must not be used.
+
+**SBS-ACS-006: Documented Justification for `Use Any API Client` Permission**
+The "Use Any API Client" permission must only be assigned to highly trusted users with documented justification and must not be granted to end-users.
+
+**SBS-ACS-007: Maintain Inventory of Non-Human Identities**
+Organizations must maintain an authoritative inventory of all non-human identities, including integration users, automation users, bot users, and API-only accounts.
+
+**SBS-ACS-008: Restrict Broad Privileges for Non-Human Identities**
+Non-human identities must not be assigned permissions that bypass sharing rules or grant administrative capabilities unless documented business justification exists.
+
+**SBS-ACS-009: Implement Compensating Controls for Privileged Non-Human Identities**
+Non-human identities with permissions that bypass sharing rules or grant administrative capabilities must have compensating controls implemented to mitigate risk.
+
+**SBS-ACS-010: Enforce Periodic Access Review and Recertification**
+All user access and configuration influencing permissions and sharing must be formally reviewed and recertified at least annually by designated business stakeholders, with documented approval and remediation of unauthorized or excessive access.
+
+**SBS-ACS-011: Enforce Governance of Access and Authorization Changes**
+All changes to Salesforce user access and authorization must be governed through a documented process that requires approval, records business justification, and produces an auditable record of the change.
+
+**SBS-ACS-012: Classify Users for Login Hours Restrictions**
+Organizations must maintain a documented classification of users who require login hours restrictions or equivalent monitoring, and must either enforce those restrictions or implement monitoring and alerting for off-hours authentication.
+
+## Authentication
+
+**SBS-AUTH-001: Enable Organization-Wide SSO Enforcement Setting**
+Salesforce production orgs must enable the org-level setting that disables Salesforce credential logins for all users.
+
+**SBS-AUTH-002: Govern and Document All Users Permitted to Bypass Single Sign-On**
+All users who do not have the "Is Single Sign-On Enabled" permission must be explicitly authorized, documented in a system of record, and limited to approved administrative or break-glass use cases.
+
+**SBS-AUTH-003: Prohibit Broad or Unrestricted Profile Login IP Ranges**
+Profiles in Salesforce production orgs must not contain login IP ranges that effectively permit access from the full public internet or other overly broad ranges that bypass network-based access controls.
+
+**SBS-AUTH-004: Enforce Strong Multi-Factor Authentication for External Users with Substantial Access to Sensitive Data**
+All Salesforce interactive authentication flows for external human users with substantial access to sensitive data must enforce multi-factor authentication that includes at least one strong authentication factor.
+
+## Code Security
+
+**SBS-CODE-001: Mandatory Peer Review for Salesforce Code Changes**
+All Salesforce code changes must undergo peer review and receive approval before merging into any production-bound branch.
+
+**SBS-CODE-002: Pre-Merge Static Code Analysis for Apex and LWC**
+Static code analysis with security checks for Apex and Lightning Web Components must execute successfully before any code change is merged into a production-bound branch.
+
+**SBS-CODE-003: Implement Persistent Apex Application Logging**
+Organizations must implement an Apex-based logging framework that writes application log events to durable Salesforce storage and must not rely on transient Salesforce debug logs for operational or security investigations.
+
+**SBS-CODE-004: Prevent Sensitive Data in Application Logs**
+Application logging frameworks must not capture, store, or transmit credentials, authentication tokens, personally identifiable information (PII), regulated data, or other sensitive values in log messages or structured log fields.
+
+## Customer Portals
+
+**SBS-CPORTAL-001: Prevent Parameter-Based Record Access in Portal Apex**
+AuraEnabled methods exposed to customer portal users must not accept user-supplied record identifiers or parameters that directly determine query scope or record access.
+
+**SBS-CPORTAL-002: Restrict Guest User Record Access**
+Guest users in customer portals must not have Create, Read, Update, or Delete permissions on standard or custom objects except as strictly required for unauthenticated user flows.
+
+**SBS-CPORTAL-003: Inventory Portal-Exposed Apex Classes and Flows**
+Organizations must maintain an authoritative inventory of all Apex classes and Autolaunched Flows exposed to Experience Cloud sites, documenting which components are accessible to external and guest users.
+
+**SBS-CPORTAL-004: Prevent Parameter-Based Record Access in Portal-Exposed Flows**
+Autolaunched Flows exposed to customer portal users must not accept user-supplied input variables that directly determine which records are accessed.
+
+**SBS-CPORTAL-005: Conduct Penetration Testing for Portal Security**
+Organizations with Experience Cloud sites must conduct penetration testing of portal security controls before initial go-live and subsequently after major releases or on a defined cadence.
+
+## Data Security
+
+**SBS-DATA-001: Implement Mechanisms to Detect Regulated Data in Long Text Area Fields**
+The organization must implement a mechanism that continuously or periodically analyzes the contents of all Long Text Area fields to identify the presence of regulated or personal data.
+
+**SBS-DATA-002: Maintain an Inventory of Long Text Area Fields Containing Regulated Data**
+The organization must maintain an up-to-date inventory of all Long Text Area fields that are known or detected to contain regulated or personal data.
+
+**SBS-DATA-003: Maintain Tested Backup and Recovery for Salesforce Data and Metadata**
+Salesforce production orgs must maintain a documented backup and recovery capability for Salesforce data and metadata, and must test restoration on a defined schedule.
+
+**SBS-DATA-004: Require Field History Tracking for Sensitive Fields**
+The organization must maintain a documented list of sensitive fields and ensure Field History Tracking is enabled for each listed field on all in-scope objects.
+
+## Deployments
+
+**SBS-DEP-001: Require a Designated Deployment Identity for Metadata Changes**
+Salesforce production orgs must designate a single deployment identity that is exclusively used for all metadata deployments and high-risk configuration changes performed through automated or scripted release processes.
+
+**SBS-DEP-002: Establish and Maintain a List of High-Risk Metadata Types Prohibited from Direct Production Editing**
+Salesforce production orgs must maintain an explicit list of high-risk metadata types that must never be edited directly in production by human users, defaulting at minimum to the SBS baseline list while allowing organizations to extend or refine it as needed.
+
+**SBS-DEP-003: Monitor and Alert on Unauthorized Modifications to High-Risk Metadata**
+Salesforce production orgs must implement a monitoring capability that detects and reports any modification to high-risk metadata performed by a user other than the designated deployment identity.
+
+**SBS-DEP-004: Establish Source-Driven Development Process**
+Meaningful Salesforce metadata changes must be deployed through a source-driven, automated, and deterministic deployment process, except where the platform does not provide programmatic deployment support.
+
+**SBS-DEP-005: Implement Secret Scanning for Salesforce Source Repositories**
+Organizations using source-driven development for Salesforce must implement automated secret scanning on all repositories containing Salesforce metadata, configuration, or deployment scripts to detect and prevent the exposure of credentials, access tokens, and other sensitive authentication material.
+
+**SBS-DEP-006: Configure Salesforce CLI Connected App with Token Expiration Policies**
+Organizations must configure the Connected App used for Salesforce CLI authentication with refresh token expiration of 90 days or less and access token timeout of 15 minutes or less.
+
+## File Security
+
+**SBS-FILE-001: Require Expiry Dates on Public Content Links**
+Organizations must ensure that Public Content links have an appropriate expiry date.
+
+**SBS-FILE-002: Require Passwords on Public Content Links for Sensitive Content**
+Organizations must ensure that Public Content links to sensitive content have a password.
+
+**SBS-FILE-003: Periodic Review and Cleanup of Public Content Links**
+Organizations must implement a recurring process to review all active Public Content links and remove or remediate links that are no longer required, lack appropriate controls, or were created outside of current policy.
+
 ## Foundations
 
-**SBS-FDNS-001: Centralized Security System of Record**  
+**SBS-FDNS-001: Centralized Security System of Record**
 The organization must maintain a centralized system of record documenting all Salesforce security configurations, exceptions, justifications, and SBS-required inventories.
+
+## Integrations
+
+**SBS-INT-001: Enforce Governance of Browser Extensions Accessing Salesforce**
+Organizations must enforce a centrally managed mechanism that restricts which browser extensions are permitted to access Salesforce, and must not allow the use of unmanaged or uncontrolled extensions.
+
+**SBS-INT-002: Inventory and Justification of Remote Site Settings**
+Organizations must maintain an authoritative inventory of all Remote Site Settings and document a business justification for each endpoint approved for Apex HTTP callouts.
+
+**SBS-INT-003: Inventory and Justification of Named Credentials**
+Organizations must maintain an authoritative inventory of all Named Credentials and document a business justification for each external endpoint and authentication configuration approved for use in Salesforce.
+
+**SBS-INT-004: Retain API Total Usage Event Logs for 30 Days**
+The organization must retain API Total Usage event log data (EventLogFile EventType=ApiTotalUsage) for at least the immediately preceding 30 days using Salesforce-native retention or automated external export and storage.
 
 ## OAuth Security
 
@@ -21,157 +163,14 @@ All OAuth-enabled Connected Apps must be recorded in an authoritative system of 
 **SBS-OAUTH-004: Due Diligence Documentation for High-Risk Connected App Vendors**
 Organizations must review and retain available security documentation for all high-risk Connected App vendors and explicitly record any missing documentation as part of the vendor assessment.
 
-## Integrations
-
-**SBS-INT-001: Enforce Governance of Browser Extensions Accessing Salesforce**  
-Organizations must enforce a centrally managed mechanism that restricts which browser extensions are permitted to access Salesforce, and must not allow the use of unmanaged or uncontrolled extensions.
-
-**SBS-INT-002: Inventory and Justification of Remote Site Settings**  
-Organizations must maintain an authoritative inventory of all Remote Site Settings and document a business justification for each endpoint approved for Apex HTTP callouts.
-
-**SBS-INT-003: Inventory and Justification of Named Credentials**  
-Organizations must maintain an authoritative inventory of all Named Credentials and document a business justification for each external endpoint and authentication configuration approved for use in Salesforce.
-
-**SBS-INT-004: Retain API Total Usage Event Logs for 30 Days**  
-The organization must retain API Total Usage event log data (EventLogFile EventType=ApiTotalUsage) for at least the immediately preceding 30 days using Salesforce-native retention or automated external export and storage.
-
-## Access Controls
-
-**SBS-ACS-001: Enforce a Documented Permission Set Model**  
-All permission sets, permission set groups, and profiles must conform to a documented model maintained in a system of record and enforced continuously.
-
-**SBS-ACS-002: Documented Justification for All `API-Enabled` Authorizations**  
-Every authorization granting the "API Enabled" permission must have documented business or technical justification recorded in a system of record.
-
-**SBS-ACS-003: Documented Justification for `Approve Uninstalled Connected Apps` Permission**  
-The "Approve Uninstalled Connected Apps" permission must only be assigned to highly trusted users with documented justification and must not be granted to end-users.
-
-**SBS-ACS-004: Documented Justification for All Super Admin–Equivalent Users**  
-All users with simultaneous View All Data, Modify All Data, and Manage Users permissions must be documented in a system of record with clear business or technical justification.
-
-**SBS-ACS-005: Only Use Custom Profiles for Active Users**  
-All active users must be assigned custom profiles. The out-of-the-box standard profiles must not be used.
-
-**SBS-ACS-006: Documented Justification for `Use Any API Client` Permission**  
-The "Use Any API Client" permission must only be assigned to highly trusted users with documented justification and must not be granted to end-users.
-
-**SBS-ACS-007: Maintain Inventory of Non-Human Identities**
-Organizations must maintain an authoritative inventory of all non-human identities, including integration users, automation users, bot users, and API-only accounts.
-
-**SBS-ACS-008: Restrict Broad Privileges for Non-Human Identities**
-Non-human identities must not be assigned permissions that bypass sharing rules or grant administrative capabilities unless documented business justification exists.
-
-**SBS-ACS-009: Implement Compensating Controls for Privileged Non-Human Identities**
-Non-human identities with permissions that bypass sharing rules or grant administrative capabilities must have compensating controls implemented to mitigate risk.
-
-**SBS-ACS-010: Enforce Periodic Access Review and Recertification**  
-All user access and configuration influencing permissions and sharing must be formally reviewed and recertified at least annually by designated business stakeholders, with documented approval and remediation of unauthorized or excessive access.
-
-**SBS-ACS-011: Enforce Governance of Access and Authorization Changes**  
-All changes to Salesforce user access and authorization must be governed through a documented process that requires approval, records business justification, and produces an auditable record of the change.
-
-**SBS-ACS-012: Classify Users for Login Hours Restrictions**  
-Organizations must maintain a documented classification of users who require login hours restrictions or equivalent monitoring, and must either enforce those restrictions or implement monitoring and alerting for off-hours authentication.
-
-## Authentication
-
-**SBS-AUTH-001: Enable Organization-Wide SSO Enforcement Setting**  
-Salesforce production orgs must enable the org-level setting that disables Salesforce credential logins for all users.
-
-**SBS-AUTH-002: Govern and Document All Users Permitted to Bypass Single Sign-On**  
-All users who do not have the "Is Single Sign-On Enabled" permission must be explicitly authorized, documented in a system of record, and limited to approved administrative or break-glass use cases.
-
-**SBS-AUTH-003: Prohibit Broad or Unrestricted Profile Login IP Ranges**  
-Profiles in Salesforce production orgs must not contain login IP ranges that effectively permit access from the full public internet or other overly broad ranges that bypass network-based access controls.
-
-**SBS-AUTH-004: Enforce Strong Multi-Factor Authentication for External Users with Substantial Access to Sensitive Data**
-All Salesforce interactive authentication flows for external human users with substantial access to sensitive data must enforce multi-factor authentication that includes at least one strong authentication factor.
-
-## Code Security
-
-**SBS-CODE-001: Mandatory Peer Review for Salesforce Code Changes**  
-All Salesforce code changes must undergo peer review and receive approval before merging into any production-bound branch.
-
-**SBS-CODE-002: Pre-Merge Static Code Analysis for Apex and LWC**  
-Static code analysis with security checks for Apex and Lightning Web Components must execute successfully before any code change is merged into a production-bound branch.
-
-**SBS-CODE-003: Implement Persistent Apex Application Logging**  
-Organizations must implement an Apex-based logging framework that writes application log events to durable Salesforce storage and must not rely on transient Salesforce debug logs for operational or security investigations.
-
-**SBS-CODE-004: Prevent Sensitive Data in Application Logs**  
-Application logging frameworks must not capture, store, or transmit credentials, authentication tokens, personally identifiable information (PII), regulated data, or other sensitive values in log messages or structured log fields.
-
-## Customer Portals
-
-**SBS-CPORTAL-001: Prevent Parameter-Based Record Access in Portal Apex**  
-AuraEnabled methods exposed to customer portal users must not accept user-supplied record identifiers or parameters that directly determine query scope or record access.
-
-**SBS-CPORTAL-002: Restrict Guest User Record Access**  
-Guest users in customer portals must not have Create, Read, Update, or Delete permissions on standard or custom objects except as strictly required for unauthenticated user flows.
-
-**SBS-CPORTAL-003: Inventory Portal-Exposed Apex Classes and Flows**  
-Organizations must maintain an authoritative inventory of all Apex classes and Autolaunched Flows exposed to Experience Cloud sites, documenting which components are accessible to external and guest users.
-
-**SBS-CPORTAL-004: Prevent Parameter-Based Record Access in Portal-Exposed Flows**  
-Autolaunched Flows exposed to customer portal users must not accept user-supplied input variables that directly determine which records are accessed.
-
-**SBS-CPORTAL-005: Conduct Penetration Testing for Portal Security**  
-Organizations with Experience Cloud sites must conduct penetration testing of portal security controls before initial go-live and subsequently after major releases or on a defined cadence.
-
-## Data Security
-
-**SBS-DATA-001: Implement Mechanisms to Detect Regulated Data in Long Text Area Fields**  
-The organization must implement a mechanism that continuously or periodically analyzes the contents of all Long Text Area fields to identify the presence of regulated or personal data.
-
-**SBS-DATA-002: Maintain an Inventory of Long Text Area Fields Containing Regulated Data**  
-The organization must maintain an up-to-date inventory of all Long Text Area fields that are known or detected to contain regulated or personal data.
-
-**SBS-DATA-003: Maintain Tested Backup and Recovery for Salesforce Data and Metadata**  
-Salesforce production orgs must maintain a documented backup and recovery capability for Salesforce data and metadata, and must test restoration on a defined schedule.
-
-**SBS-DATA-004: Require Field History Tracking for Sensitive Fields**  
-The organization must maintain a documented list of sensitive fields and ensure Field History Tracking is enabled for each listed field on all in-scope objects.
-
-## File Security
-
-**SBS-FILE-001: Require Expiry Dates on Public Content Links**  
-Organizations must ensure that Public Content links have an appropriate expiry date.
-
-**SBS-FILE-002: Require Passwords on Public Content Links for Sensitive Content**  
-Organizations must ensure that Public Content links to sensitive content have a password.
-
-**SBS-FILE-003: Periodic Review and Cleanup of Public Content Links**  
-Organizations must implement a recurring process to review all active Public Content links and remove or remediate links that are no longer required, lack appropriate controls, or were created outside of current policy.
-
-## Deployments
-
-**SBS-DEP-001: Require a Designated Deployment Identity for Metadata Changes**  
-Salesforce production orgs must designate a single deployment identity that is exclusively used for all metadata deployments and high-risk configuration changes performed through automated or scripted release processes.
-
-**SBS-DEP-002: Establish and Maintain a List of High-Risk Metadata Types Prohibited from Direct Production Editing**  
-Salesforce production orgs must maintain an explicit list of high-risk metadata types that must never be edited directly in production by human users, defaulting at minimum to the SBS baseline list while allowing organizations to extend or refine it as needed.
-
-**SBS-DEP-003: Monitor and Alert on Unauthorized Modifications to High-Risk Metadata**  
-Salesforce production orgs must implement a monitoring capability that detects and reports any modification to high-risk metadata performed by a user other than the designated deployment identity.
-
-**SBS-DEP-004: Establish Source-Driven Development Process**  
-Meaningful Salesforce metadata changes must be deployed through a source-driven, automated, and deterministic deployment process, except where the platform does not provide programmatic deployment support.
-
-**SBS-DEP-005: Implement Secret Scanning for Salesforce Source Repositories**  
-Organizations using source-driven development for Salesforce must implement automated secret scanning on all repositories containing Salesforce metadata, configuration, or deployment scripts to detect and prevent the exposure of credentials, access tokens, and other sensitive authentication material.
-
-**SBS-DEP-006: Configure Salesforce CLI Connected App with Token Expiration Policies**  
-Organizations must configure the Connected App used for Salesforce CLI authentication with refresh token expiration of 90 days or less and access token timeout of 15 minutes or less.
-
 ## Security Configuration
 
-**SBS-SECCONF-001: Establish a Salesforce Health Check Baseline**  
+**SBS-SECCONF-001: Establish a Salesforce Health Check Baseline**
 Salesforce production orgs must define and maintain a Salesforce Health Check baseline—including Salesforce's native baseline XML or an equivalent customized baseline—and ensure it reflects the organization's intentional security configuration posture.
 
-**SBS-SECCONF-002: Review and Remediate Salesforce Health Check Deviations**  
+**SBS-SECCONF-002: Review and Remediate Salesforce Health Check Deviations**
 Salesforce production orgs must periodically review Health Check results against the defined baseline and remediate deviations or formally document approved exceptions.
 
 ---
 
 *Total Controls: 49*
-

--- a/controls-at-a-glance.md
+++ b/controls-at-a-glance.md
@@ -86,7 +86,7 @@ Autolaunched Flows exposed to customer portal users must not accept user-supplie
 Organizations with Experience Cloud sites must conduct penetration testing of portal security controls before initial go-live and subsequently after major releases or on a defined cadence.
 
 **SBS-CPORTAL-006: Minimize Object and Field Permissions for Authenticated Portal User Profiles and Permission Sets**
-Authenticated portal user profiles and permission sets must restrict object-level (CRUD) and field-level (FLS) permissions to only those objects and fields required for portal functionality. Objects not used by any portal component must have all permissions removed from external user profiles and permission sets.
+Authenticated portal user profiles and permission sets must only provide object-level (CRUD) and field-level (FLS) permissions to those objects and fields required for portal functionality. Objects not used by any portal component must have all permissions removed from external user profiles and permission sets.
 
 **SBS-CPORTAL-007: Restrict External Organization-Wide Default Sharing Settings**
 External Organization-Wide Default (OWD) sharing settings must be set to Private for all objects containing sensitive or internal data accessible by portal users. Objects must not use Public Read Only or Public Read/Write external sharing defaults unless a documented business justification exists and compensating controls are in place.


### PR DESCRIPTION
## Summary
Adds two new controls around digital experience sites to prevent leaking data due to lax object/field-level permissions in portal profiles/permission sets and/or org-wide default external sharing settings
 
## Changes
* Adds SBS-CPORTAL-006 (Minimize Object and Field Permissions for Authenticated Portal User Profiles and Permission Sets) & SBS-CPORTAL-007 (Restrict External Organization-Wide Default Sharing Settings)
* Adds corresponding control metadata YAML files
* Updates controls-at-a-glance.md file accordingly

## Notes
* This branch piggybacks off that from #28, which should be approved/merged first

